### PR TITLE
Update deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,9 +4,9 @@
         org.clojure/core.async {:mvn/version "0.7.559"}
         lilactown/helix {:mvn/version "0.0.14"}
         funcool/promesa {:mvn/version "5.1.0"}
-        camel-snake-kebab {:mvn/version "0.4.1"}
-        medley {:mvn/version "1.2.0"}
-        cljs-ajax {:mvn/version "0.8.0"}
+        camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.1"}
+        medley/medley {:mvn/version "1.2.0"}
+        cljs-ajax/cljs-ajax {:mvn/version "0.8.0"}
         keechma/next {:mvn/version "0.0.8"}
         keechma/router {:mvn/version "1.0.0"}
         keechma/entitydb {:mvn/version "2.0.3"}
@@ -14,5 +14,5 @@
         keechma/forms {:mvn/version "0.1.7"}
         keechma/malli-forms {:git/url "https://github.com/keechma/keechma-malli-forms"
                              :sha "3c784fb697d1c4cb7719a086575df2eea89615b3"}
-        cljs-bean {:mvn/version "1.5.0"}
+        cljs-bean/cljs-bean {:mvn/version "1.5.0"}
         binaryage/oops {:mvn/version "0.7.0"}}}


### PR DESCRIPTION
Minor fix for deprecated warning you get when you build a keechma project:

`DEPRECATED: Libs must be qualified, change camel-snake-kebab => camel-snake-kebab/camel-snake-kebab (/Users/miro/.gitlibs/libs/keechma.next/toolbox/dc6335a6a1f5f941d5388c057382558b24fa5c22/deps.edn)
DEPRECATED: Libs must be qualified, change medley => medley/medley (/Users/miro/.gitlibs/libs/keechma.next/toolbox/dc6335a6a1f5f941d5388c057382558b24fa5c22/deps.edn)
DEPRECATED: Libs must be qualified, change cljs-ajax => cljs-ajax/cljs-ajax (/Users/miro/.gitlibs/libs/keechma.next/toolbox/dc6335a6a1f5f941d5388c057382558b24fa5c22/deps.edn)
DEPRECATED: Libs must be qualified, change cljs-bean => cljs-bean/cljs-bean (/Users/miro/.gitlibs/libs/keechma.next/toolbox/dc6335a6a1f5f941d5388c057382558b24fa5c22/deps.edn)
DEPRECATED: Libs must be qualified, change camel-snake-kebab => camel-snake-kebab/camel-snake-kebab (/Users/miro/.gitlibs/libs/keechma.next/toolbox/dc6335a6a1f5f941d5388c057382558b24fa5c22/deps.edn)
DEPRECATED: Libs must be qualified, change medley => medley/medley (/Users/miro/.gitlibs/libs/keechma.next/toolbox/dc6335a6a1f5f941d5388c057382558b24fa5c22/deps.edn)
DEPRECATED: Libs must be qualified, change cljs-ajax => cljs-ajax/cljs-ajax (/Users/miro/.gitlibs/libs/keechma.next/toolbox/dc6335a6a1f5f941d5388c057382558b24fa5c22/deps.edn)
DEPRECATED: Libs must be qualified, change cljs-bean => cljs-bean/cljs-bean (/Users/miro/.gitlibs/libs/keechma.next/toolbox/dc6335a6a1f5f941d5388c057382558b24fa5c22/deps.edn)`