### PR TITLE
Expose use-valid fn to UI

### DIFF
--- a/src/keechma/next/controllers/malli_form/ui.cljs
+++ b/src/keechma/next/controllers/malli_form/ui.cljs
@@ -25,6 +25,14 @@
                               (mf/get-in-errors form attr))))]
     (mf/format-error-messages (use-meta-sub props controller get-in-errors-cb))))
 
+(defn use-valid? [props controller]
+  (let [get-valid? (hooks/use-callback
+                     :once
+                     (fn [meta-state]
+                       (when-let [form (mfc/get-form meta-state)]
+                         (mf/valid? form))))]
+    (mf/format-error-messages (use-meta-sub props controller get-valid?))))
+
 (defn on-partial-change
   ([props controller attr value] (on-partial-change props controller attr value {}))
   ([props controller attr value opts]


### PR DESCRIPTION
Expose `mf/valid?` to be used from UI